### PR TITLE
Integrate PayPal API into Pagos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+/app/src/main/res/values/secrets.xml

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,11 +4,11 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-06-10T16:53:47.895369200Z">
+        <DropdownSelection timestamp="2025-06-28T03:16:28.666583024Z">
           <Target type="DEFAULT_BOOT">
-            <template>
-              <DeviceId pluginId="FirebaseDirectAccess" type="TEMPLATE" identifier="model_id=tokay/35" />
-            </template>
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=/home/gimblet/.android/avd/Pixel_9.avd" />
+            </handle>
           </Target>
         </DropdownSelection>
         <DialogSelection />

--- a/README.md
+++ b/README.md
@@ -6,7 +6,25 @@
   <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg" alt="C#" width="40" height="40"/>
   <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg" alt="C#" width="40" height="40"/>
   <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" alt="C#" width="40" height="40"/>
-  
+
 - ### Database **SQL**
   <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/firebase/firebase-original.svg" alt="C#" width="40" height="40"/>
+
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+### Secrets Management
+
+If you want to use the Paypal Integration in the app you need to create a secrets.xml inside the res
+folder. There is template called secrets-template.xml that you may use if you need a guide.
+
+Inside that file you need to set your paypal client id and secret id accordingly so the sdk can use
+it.
+
+In order to get these ids you need to go to : developer.paypal.com and create and sandboxed app
+where you will see this values. Inside the app settings you need to enable the option login with
+paypal and create a new return url with this name:
+
+com.powidev.coffeshop://paypalActivity
+
+Once done that simply rebuild the app and test the integration in sandbox.paypal.com and enter your
+newly created bussiness/personal sandboxed accounts.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,4 +54,8 @@ dependencies {
     implementation(libs.glide)
     implementation(libs.gson)
     implementation(libs.lottie)
+
+    implementation(libs.fast.android.networking.android.networking)
+    implementation(libs.okhttp)
+    implementation(libs.paypal.web.payments)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -12,6 +14,18 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.CoffeShop"
         tools:targetApi="31">
+        <activity
+            android:name=".Activity.payment.PaypalActivity"
+            android:exported="true"
+            android:launchMode="singleTop">
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <data android:scheme="com.powidev.coffeshop" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
+        </activity>
         <activity
             android:name=".Activity.OrderDetailsActivity"
             android:exported="false" />
@@ -35,13 +49,13 @@
             android:exported="false" />
         <activity
             android:name=".Activity.MainActivity"
-            android:exported="true" />
+            android:exported="true">
+        </activity>
         <activity
             android:name=".Activity.SplashActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/powidev/coffeshop/Activity/payment/PaymentActivity.kt
+++ b/app/src/main/java/com/powidev/coffeshop/Activity/payment/PaymentActivity.kt
@@ -66,7 +66,7 @@ class PaymentActivity : AppCompatActivity() {
             when (selectedPaymentPosition) {
                 0 -> handleCashPayment()
                 1 -> Toast.makeText(this, "Yape payment selected", Toast.LENGTH_SHORT).show()
-                2 -> Toast.makeText(this, "PayPal payment selected", Toast.LENGTH_SHORT).show()
+                2 -> handlePaypalPayment()
                 3 -> Toast.makeText(this, "Credit/Debit Card payment selected", Toast.LENGTH_SHORT)
                     .show()
 
@@ -90,6 +90,9 @@ class PaymentActivity : AppCompatActivity() {
             cashPayment.saveOrder()
             startActivity(Intent(this, MainActivity::class.java))
         }, 1500)
+    }
 
+    private fun handlePaypalPayment() {
+        startActivity(Intent(this, PaypalActivity::class.java))
     }
 }

--- a/app/src/main/java/com/powidev/coffeshop/Activity/payment/PaypalActivity.kt
+++ b/app/src/main/java/com/powidev/coffeshop/Activity/payment/PaypalActivity.kt
@@ -2,6 +2,7 @@ package com.powidev.coffeshop.Activity.payment
 
 import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
 import android.util.Base64
 import android.util.Log
 import android.widget.Toast
@@ -23,6 +24,7 @@ import com.powidev.coffeshop.Activity.MainActivity
 import com.powidev.coffeshop.Domain.OrderDetailModel
 import com.powidev.coffeshop.Domain.OrderModel
 import com.powidev.coffeshop.Domain.PaymentType
+import com.powidev.coffeshop.Helper.LoadingDialogFragment
 import com.powidev.coffeshop.Helper.ManagmentCart
 import com.powidev.coffeshop.Helper.OrderDBHelper
 import com.powidev.coffeshop.Helper.OrderDetailDBHelper
@@ -37,6 +39,7 @@ import java.util.UUID
 
 class PaypalActivity : AppCompatActivity() {
     private lateinit var binding: ActivityPaypalBinding
+    private val loadingDialogFragment by lazy { LoadingDialogFragment() }
 
     //Paypal
     private lateinit var clientID: String
@@ -70,9 +73,14 @@ class PaypalActivity : AppCompatActivity() {
             fetchAccessToken()
         }
 
-        binding.paypalpay.setOnClickListener {
+        loadingDialogFragment.show(supportFragmentManager, "loader")
+
+        Handler(mainLooper).postDelayed({
+            if (loadingDialogFragment.isAdded) {
+                loadingDialogFragment.dismissAllowingStateLoss()
+            }
             startPayment()
-        }
+        }, 1500)
     }
 
     private fun readPaypalSecrets(): Boolean {
@@ -105,14 +113,18 @@ class PaypalActivity : AppCompatActivity() {
 
                     Toast.makeText(
                         this@PaypalActivity,
-                        "Access Token Fetched!",
+                        resources.getString(R.string.paypal_loaded_succesfully),
                         Toast.LENGTH_SHORT
                     ).show()
                 }
 
                 override fun onError(error: ANError) {
                     Log.d("debug", error.errorBody)
-                    Toast.makeText(this@PaypalActivity, "Error Occurred!", Toast.LENGTH_SHORT)
+                    Toast.makeText(
+                        this@PaypalActivity,
+                        resources.getString(R.string.paypal_could_not_load),
+                        Toast.LENGTH_SHORT
+                    )
                         .show()
                 }
             })
@@ -215,11 +227,19 @@ class PaypalActivity : AppCompatActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         Log.d("debug", "onNewIntent: $intent")
-        if(intent.data!!.getQueryParameter("opType") == "payment") {
+        if (intent.data!!.getQueryParameter("opType") == "payment") {
             captureOrder(orderId)
-            Toast.makeText(this, "Payment Successful", Toast.LENGTH_SHORT).show()
+            Toast.makeText(
+                this,
+                resources.getString(R.string.payment_successful),
+                Toast.LENGTH_SHORT
+            ).show()
         } else if (intent.data!!.getQueryParameter("opType") == "cancel") {
-            Toast.makeText(this, "Payment Canceled", Toast.LENGTH_SHORT).show()
+            Toast.makeText(
+                this,
+                resources.getString(R.string.payment_cancelled),
+                Toast.LENGTH_SHORT
+            ).show()
         }
     }
 

--- a/app/src/main/java/com/powidev/coffeshop/Activity/payment/PaypalActivity.kt
+++ b/app/src/main/java/com/powidev/coffeshop/Activity/payment/PaypalActivity.kt
@@ -1,0 +1,287 @@
+package com.powidev.coffeshop.Activity.payment
+
+import android.content.Intent
+import android.os.Bundle
+import android.util.Base64
+import android.util.Log
+import android.widget.Toast
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import com.androidnetworking.AndroidNetworking
+import com.androidnetworking.common.Priority
+import com.androidnetworking.error.ANError
+import com.androidnetworking.interfaces.JSONObjectRequestListener
+import com.paypal.android.corepayments.CoreConfig
+import com.paypal.android.corepayments.Environment
+import com.paypal.android.corepayments.PayPalSDKError
+import com.paypal.android.paypalwebpayments.PayPalWebCheckoutClient
+import com.paypal.android.paypalwebpayments.PayPalWebCheckoutFundingSource
+import com.paypal.android.paypalwebpayments.PayPalWebCheckoutListener
+import com.paypal.android.paypalwebpayments.PayPalWebCheckoutRequest
+import com.paypal.android.paypalwebpayments.PayPalWebCheckoutResult
+import com.powidev.coffeshop.Activity.MainActivity
+import com.powidev.coffeshop.Domain.OrderDetailModel
+import com.powidev.coffeshop.Domain.OrderModel
+import com.powidev.coffeshop.Domain.PaymentType
+import com.powidev.coffeshop.Helper.ManagmentCart
+import com.powidev.coffeshop.Helper.OrderDBHelper
+import com.powidev.coffeshop.Helper.OrderDetailDBHelper
+import com.powidev.coffeshop.R
+import com.powidev.coffeshop.databinding.ActivityPaypalBinding
+import org.json.JSONArray
+import org.json.JSONObject
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
+
+class PaypalActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityPaypalBinding
+
+    //Paypal
+    private lateinit var clientID: String
+    private lateinit var secretID: String
+    private lateinit var accessToken: String
+    private lateinit var uniqueId: String
+    private lateinit var orderId: String
+
+    private val returnUrl = "com.powidev.coffeshop://paypalActivity"
+
+    //SQLite
+    private lateinit var orderDBHelper: OrderDBHelper
+    private lateinit var orderDetailDBHelper: OrderDetailDBHelper
+    private lateinit var managementCart: ManagmentCart
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        AndroidNetworking.initialize(this)
+
+        binding = ActivityPaypalBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        enableEdgeToEdge()
+
+        managementCart = ManagmentCart(this)
+
+        if (!readPaypalSecrets()) {
+            Toast.makeText(this, R.string.something_went_wrong, Toast.LENGTH_SHORT).show()
+            finish()
+            startActivity(Intent(this, MainActivity::class.java))
+        } else {
+            fetchAccessToken()
+        }
+
+        binding.paypalpay.setOnClickListener {
+            startPayment()
+        }
+    }
+
+    private fun readPaypalSecrets(): Boolean {
+        var result = false
+
+        try {
+            clientID = resources.getString(R.string.client_id)
+            secretID = resources.getString(R.string.secret_id)
+            result = true
+        } catch (e: Exception) {
+            Log.d("debug", "SECRETS.xml not found", e)
+        }
+
+        return result;
+    }
+
+    private fun fetchAccessToken() {
+        val encodedAuthString =
+            Base64.encodeToString("$clientID:$secretID".toByteArray(), Base64.NO_WRAP)
+
+        AndroidNetworking.post("https://api-m.sandbox.paypal.com/v1/oauth2/token")
+            .addHeaders("Authorization", "Basic $encodedAuthString")
+            .addHeaders("Content-Type", "application/x-www-form-urlencoded")
+            .addBodyParameter("grant_type", "client_credentials")
+            .setPriority(Priority.HIGH)
+            .build()
+            .getAsJSONObject(object : JSONObjectRequestListener {
+                override fun onResponse(response: JSONObject) {
+                    accessToken = response.getString("access_token")
+
+                    Toast.makeText(
+                        this@PaypalActivity,
+                        "Access Token Fetched!",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+
+                override fun onError(error: ANError) {
+                    Log.d("debug", error.errorBody)
+                    Toast.makeText(this@PaypalActivity, "Error Occurred!", Toast.LENGTH_SHORT)
+                        .show()
+                }
+            })
+    }
+
+    private fun startPayment() {
+        uniqueId = UUID.randomUUID().toString()
+
+        val orderRequestJson = JSONObject().apply {
+            put("intent", "CAPTURE")
+            put("purchase_units", JSONArray().apply {
+                put(JSONObject().apply {
+                    put("reference_id", uniqueId)
+                    put("amount", JSONObject().apply {
+                        put("currency_code", "USD")
+//                        put("value", "5.00")
+                        put("value", managementCart.getCalculatedFee().toString())
+                    })
+                })
+            })
+            put("payment_source", JSONObject().apply {
+                put("paypal", JSONObject().apply {
+                    put("experience_context", JSONObject().apply {
+                        put("payment_method_preference", "IMMEDIATE_PAYMENT_REQUIRED")
+                        put("brand_name", "Coffee Shop S.A")
+                        put("locale", "en-US")
+                        put("landing_page", "LOGIN")
+                        put("shipping_preference", "NO_SHIPPING")
+                        put("user_action", "PAY_NOW")
+                        put("return_url", returnUrl)
+                        put("cancel_url", returnUrl)
+                    })
+                })
+            })
+        }
+
+        AndroidNetworking.post("https://api-m.sandbox.paypal.com/v2/checkout/orders")
+            .addHeaders("Authorization", "Bearer $accessToken")
+            .addHeaders("Content-Type", "application/json")
+            .addHeaders("PayPal-Request-Id", uniqueId)
+            .addJSONObjectBody(orderRequestJson)
+            .setPriority(Priority.HIGH)
+            .build()
+            .getAsJSONObject(object : JSONObjectRequestListener {
+                override fun onResponse(response: JSONObject) {
+                    handleOrderID(response.getString("id"))
+                }
+
+                override fun onError(error: ANError) {
+                    Log.d(
+                        "debug",
+                        "Order Error : ${error.message} || ${error.errorBody} || ${error.response}"
+                    )
+                    Toast.makeText(
+                        this@PaypalActivity,
+                        getString(R.string.something_went_wrong),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                    endActivity()
+                }
+            })
+    }
+
+    private fun handleOrderID(orderID: String) {
+        val config = CoreConfig(clientID, environment = Environment.SANDBOX)
+        val payPalWebCheckoutClient =
+            PayPalWebCheckoutClient(this@PaypalActivity, config, returnUrl)
+        payPalWebCheckoutClient.listener = object : PayPalWebCheckoutListener {
+            override fun onPayPalWebSuccess(result: PayPalWebCheckoutResult) {
+                Log.d("debug", "onPayPalWebSuccess: $result")
+                Toast.makeText(
+                    this@PaypalActivity,
+                    resources.getString(R.string.payment_successful),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+
+            override fun onPayPalWebFailure(error: PayPalSDKError) {
+                Log.d("debug", "onPayPalWebFailure: $error")
+                Toast.makeText(
+                    this@PaypalActivity,
+                    resources.getString(R.string.something_went_wrong),
+                    Toast.LENGTH_SHORT
+                ).show()
+                endActivity()
+            }
+
+            override fun onPayPalWebCanceled() {
+                Log.d("debug", "onPayPalWebCanceled: ")
+                endActivity()
+            }
+        }
+
+        orderId = orderID
+        val payPalWebCheckoutRequest =
+            PayPalWebCheckoutRequest(orderID, fundingSource = PayPalWebCheckoutFundingSource.PAYPAL)
+        payPalWebCheckoutClient.start(payPalWebCheckoutRequest)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        Log.d("debug", "onNewIntent: $intent")
+        if(intent.data!!.getQueryParameter("opType") == "payment") {
+            captureOrder(orderId)
+            Toast.makeText(this, "Payment Successful", Toast.LENGTH_SHORT).show()
+        } else if (intent.data!!.getQueryParameter("opType") == "cancel") {
+            Toast.makeText(this, "Payment Canceled", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun captureOrder(orderID: String) {
+        Log.d("debug", "captureOrder: $orderID")
+        AndroidNetworking.post("https://api-m.sandbox.paypal.com/v2/checkout/orders/$orderID/capture")
+            .addHeaders("Authorization", "Bearer $accessToken")
+            .addHeaders("Content-Type", "application/json")
+            .addJSONObjectBody(JSONObject())
+            .setPriority(Priority.HIGH)
+            .build()
+            .getAsJSONObject(object : JSONObjectRequestListener {
+                override fun onResponse(response: JSONObject) {
+                    Log.d("debug", "Capture Response : " + response.toString())
+                    saveOrderInSQLite()
+                }
+
+                override fun onError(error: ANError) {
+                    Log.e("debug", "Capture Error : " + error.errorDetail)
+                    Toast.makeText(
+                        this@PaypalActivity,
+                        resources.getString(R.string.could_not_capture_order),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                    endActivity()
+                }
+            })
+    }
+
+    private fun endActivity() {
+        finish()
+        startActivity(Intent(this@PaypalActivity, MainActivity::class.java))
+    }
+
+    fun saveOrderInSQLite() {
+        orderDBHelper = OrderDBHelper(this)
+        orderDetailDBHelper = OrderDetailDBHelper(this)
+
+        val format = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        val currentDate = format.format(Date())
+
+        val order = OrderModel(
+            date = currentDate,
+            totalPrice = managementCart.getCalculatedFee(),
+            grossPrice = managementCart.getTotalFee(),
+            paymentType = PaymentType.PAYPAL
+        )
+        val orderId = orderDBHelper.insertOrder(order)
+
+        if (orderId.toInt() == -1) {
+            Toast.makeText(
+                this,
+                resources.getString(R.string.something_went_wrong),
+                Toast.LENGTH_SHORT
+            ).show()
+            return
+        }
+
+        managementCart.getListCart().forEach {
+            val order = OrderDetailModel(it.title, it.price, it.numberInCart, orderId.toInt())
+            orderDetailDBHelper.insertOrder(order)
+        }
+        managementCart.clearListCart()
+    }
+}

--- a/app/src/main/res/layout/activity_paypal.xml
+++ b/app/src/main/res/layout/activity_paypal.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/cream"
+    tools:context=".Activity.payment.PaypalActivity">
+
+    <TextView
+        android:id="@+id/paypalpay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:textColor="@color/darkBrown"
+        android:text="@string/paypal_payment_in_progress"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:gravity="center"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -44,4 +44,8 @@
     <string name="order_detail">Order details</string>
     <string name="gross_amount">"Gross amount: "</string>
     <string name="payment_type_plus_sign">"Payment type: "</string>
+    <string name="paypal_payment_in_progress">Paypal Payment in progress…</string>
+    <string name="payment_cancelled">The payment was cancelled</string>
+    <string name="could_not_capture_order">Couldn\'t capture PayPal\norder details</string>
+    <string name="payment_successful">Payment successful, enjoy!</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -48,4 +48,6 @@
     <string name="payment_cancelled">The payment was cancelled</string>
     <string name="could_not_capture_order">Couldn\'t capture PayPal\norder details</string>
     <string name="payment_successful">Payment successful, enjoy!</string>
+    <string name="paypal_loaded_succesfully">Paypal was loaded successfully!</string>
+    <string name="paypal_could_not_load">There was a problem while\ntrying to load PayPal</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -48,4 +48,6 @@
     <string name="payment_cancelled">El pago fue cancelado</string>
     <string name="could_not_capture_order">No se pudieron obtener\nlos detalles del pedido de PayPal</string>
     <string name="payment_successful">Pago correcto, disfruta!</string>
+    <string name="paypal_loaded_succesfully">Paypal se cargó correctamente!</string>
+    <string name="paypal_could_not_load">Ocurrió un problema\nal intentar cargar PayPal</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -44,4 +44,8 @@
     <string name="order_detail">Detalles del pedido</string>
     <string name="gross_amount">"Monto neto: "</string>
     <string name="payment_type_plus_sign">"Tipo de pago: "</string>
+    <string name="paypal_payment_in_progress">Pago de PayPal en progreso…</string>
+    <string name="payment_cancelled">El pago fue cancelado</string>
+    <string name="could_not_capture_order">No se pudieron obtener\nlos detalles del pedido de PayPal</string>
+    <string name="payment_successful">Pago correcto, disfruta!</string>
 </resources>

--- a/app/src/main/res/values/secrets-template.xml
+++ b/app/src/main/res/values/secrets-template.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+<!--    <string name="client_id">SET CLIENT ID IN HERE</string>-->
+<!--    <string name="secret_id">SET SECRET ID IN HERE</string>-->
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,4 +59,6 @@
     <string name="payment_cancelled">The payment was cancelled</string>
     <string name="could_not_capture_order">Couldn\'t capture PayPal\norder details</string>
     <string name="payment_successful">Payment successful, enjoy!</string>
+    <string name="paypal_loaded_succesfully">Paypal was loaded successfully!</string>
+    <string name="paypal_could_not_load">There was a problem while\ntrying to load PayPal</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,4 +55,8 @@
     <string name="delivery_plus_sign" translatable="false">"Delivery: "</string>
     <string name="total_plus_sign" translatable="false">"Total: "</string>
     <string name="payment_type_plus_sign">"Payment type: "</string>
+    <string name="paypal_payment_in_progress">Paypal Payment in progress…</string>
+    <string name="payment_cancelled">The payment was cancelled</string>
+    <string name="could_not_capture_order">Couldn\'t capture PayPal\norder details</string>
+    <string name="payment_successful">Payment successful, enjoy!</string>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.enableJetifier=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.10.0"
+androidNetworkingVersion = "1.0.4"
 glide = "4.13.0"
 gson = "2.11.0"
 kotlin = "2.0.21"
@@ -14,9 +15,12 @@ activity = "1.10.1"
 constraintlayout = "2.2.1"
 googleGmsGoogleServices = "4.4.2"
 firebaseDatabase = "21.0.0"
+okhttp = "4.12.0"
+paypalWebPayments = "1.5.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+fast-android-networking-android-networking = { module = "com.github.amitshekhariitbhu.Fast-Android-Networking:android-networking", version.ref = "androidNetworkingVersion" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -28,6 +32,8 @@ material = { group = "com.google.android.material", name = "material", version.r
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 firebase-database = { group = "com.google.firebase", name = "firebase-database", version.ref = "firebaseDatabase" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+paypal-web-payments = { module = "com.paypal.android:paypal-web-payments", version.ref = "paypalWebPayments" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven {
+            setUrl("https://jitpack.io")
+        }
     }
 }
 


### PR DESCRIPTION
This PR integrates de PayPal API as well as secrets managements

In order to integrate PayPal some dependencies had to be added to facilitate networking and the PayPal SDK altogether.

The readme was updated in order to include a small guide into how to anyone could integrate their own PayPal API into the app and test this integration.

To support the above a secret file has to be added. See secrets-template.xml for more info 